### PR TITLE
商品一覧表示の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :items
-  
+
   with_options presence: true do
     validates :nickname
     with_options format: { with: /\A[ぁ-んァ-ン一-龥々]/, message: '全角ひらがな、全角カタカナ、漢字で入力して下さい' } do

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,9 +127,9 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-          <% @items.each do |item| %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
               <%# 商品が売れていればsold outを表示しましょう %>
@@ -151,8 +151,8 @@
               </div>
             </div>
           <% end %>
-        <% end %>
-      </li>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @items = nil %>
         <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,53 +129,50 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <% @items.each do |item| %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
             </div>
-          </div>
-        </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.shipping_fee_id %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @items = nil %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -142,7 +142,7 @@
                   <%= item.name %>
                 </h3>
                 <div class='item-price'>
-                  <span><%= item.price %>円<br><%= item.shipping_fee_id %></span>
+                  <span><%= item.price %>円<br><%= ShippingFee.find(item.shipping_fee_id).name %></span>
                   <div class='star-btn'>
                     <%= image_tag "star.png", class:"star-icon" %>
                     <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,36 +125,34 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to "#" do %>
-            <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" %>
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
+      <% if @items.exists?  %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
               </div>
-              <%# //商品が売れていればsold outを表示しましょう %>
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br><%= item.shipping_fee_id %></span>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.shipping_fee_id %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
                 </div>
               </div>
-            </div>
-          <% end %>
-        </li>
-      <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% if @items = nil %>
+            <% end %>
+          </li>
+        <% end %>
+      <% else %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -29,27 +29,27 @@ RSpec.describe Item, type: :model do
       it '商品のカテゴリー空では登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it '商品の状態が空では登録できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
       it '配送料の負担が空だと登録できない' do
         @item.shipping_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping fee must be other than 1')
       end
       it '発送元の地域が空では登録できない' do
         @item.shipping_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping area must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping area must be other than 1')
       end
       it '発送までの日数が空では登録できない' do
         @item.shipping_time_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping time must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping time must be other than 1')
       end
       it '価格が空では登録できない' do
         @item.price = ''
@@ -61,28 +61,28 @@ RSpec.describe Item, type: :model do
         @item.valid?
       end
       it '価格が9,999,999円を超えていたら登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
       end
       it '商品価格が半角英数字混合では出品できない' do
         @item.price = '1111aaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '商品価格が半角英字のみでは出品できない' do
         @item.price = 'aaaaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '商品価格が全角文字では出品できない' do
         @item.price = 'ああああああああ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '商品価格が全角数字では出品できない' do
         @item.price = '１１１１１１'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,31 +45,31 @@ RSpec.describe User, type: :model do
       it 'emailに＠がないと登録できない' do
         @user.email = 'test'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include('Email is invalid')
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = 'aaa00'
         @user.password_confirmation = 'aaa00'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
       end
       it 'passwordが英字のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include()
+        expect(@user.errors.full_messages).to include
       end
       it 'passwordが数字のみでは登録できない' do
         @user.password = '000000'
         @user.password_confirmation = '000000'
         @user.valid?
-        expect(@user.errors.full_messages).to include()
+        expect(@user.errors.full_messages).to include
       end
       it 'passwordが全角では登録できない' do
         @user.password = 'ああああaaaa0000'
         @user.password_confirmation = 'ああああaaaa0000'
         @user.valid?
-        expect(@user.errors.full_messages).to include()
+        expect(@user.errors.full_messages).to include
       end
     end
   end
@@ -77,42 +77,42 @@ RSpec.describe User, type: :model do
     it 'ユーザー名字が空では登録できない' do
       @user.lastname = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Lastname can't be blank", "Lastname 全角ひらがな、全角カタカナ、漢字で入力して下さい")
+      expect(@user.errors.full_messages).to include("Lastname can't be blank", 'Lastname 全角ひらがな、全角カタカナ、漢字で入力して下さい')
     end
     it 'ユーザー名前が空では登録できない' do
       @user.firstname = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Firstname can't be blank", "Firstname 全角ひらがな、全角カタカナ、漢字で入力して下さい")
+      expect(@user.errors.full_messages).to include("Firstname can't be blank", 'Firstname 全角ひらがな、全角カタカナ、漢字で入力して下さい')
     end
     it 'ユーザー名字が半角では登録できない' do
       @user.lastname = 'aaaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Lastname 全角ひらがな、全角カタカナ、漢字で入力して下さい")
+      expect(@user.errors.full_messages).to include('Lastname 全角ひらがな、全角カタカナ、漢字で入力して下さい')
     end
     it 'ユーザー名前が半角では登録できない' do
       @user.firstname = 'aaaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Firstname 全角ひらがな、全角カタカナ、漢字で入力して下さい")
+      expect(@user.errors.full_messages).to include('Firstname 全角ひらがな、全角カタカナ、漢字で入力して下さい')
     end
     it 'ユーザー名字のフリガナが空では登録できない' do
       @user.lastname_kana = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Lastname kana can't be blank", "Lastname kana 全角カタカナで入力して下さい")
+      expect(@user.errors.full_messages).to include("Lastname kana can't be blank", 'Lastname kana 全角カタカナで入力して下さい')
     end
     it 'ユーザー名前のフリガナが空では登録できない' do
       @user.firstname_kana = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Firstname kana can't be blank", "Firstname kana 全角カタカナで入力して下さい")
+      expect(@user.errors.full_messages).to include("Firstname kana can't be blank", 'Firstname kana 全角カタカナで入力して下さい')
     end
     it 'ユーザー名字が半角では登録できない' do
       @user.lastname_kana = 'aaaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Lastname kana 全角カタカナで入力して下さい")
+      expect(@user.errors.full_messages).to include('Lastname kana 全角カタカナで入力して下さい')
     end
     it 'ユーザー名前が半角では登録できない' do
       @user.firstname_kana = 'aaaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Firstname kana 全角カタカナで入力して下さい")
+      expect(@user.errors.full_messages).to include('Firstname kana 全角カタカナで入力して下さい')
     end
     it '生年月日が空では登録できない' do
       @user.birthday = ''


### PR DESCRIPTION
# What
出品された商品の一覧表示をする機能を実装した
売却済みのものにはSoldOutの表示をつける機能は未実装
# Why
出品したものを一覧で表示したいため
購入機能の実装はまだ行なっていないため

機能の動画
・出品した商品が追加表示される
https://gyazo.com/99a9dd929d367509a97746a5f0709795
・新しい順で表示されている
https://gyazo.com/32e11c7bcd4e161182e827bf57cb3469
https://gyazo.com/855c3ee655c521ac1922c974acbd5098
・ログアウトしても一覧が表示される
https://gyazo.com/635b317ad2935d5796ec60a05a9098bc
